### PR TITLE
Derive macros for simple enums

### DIFF
--- a/opcua-macros/src/encoding/attribute.rs
+++ b/opcua-macros/src/encoding/attribute.rs
@@ -6,7 +6,9 @@ use crate::utils::ItemAttr;
 pub(crate) struct EncodingFieldAttribute {
     pub rename: Option<String>,
     pub ignore: bool,
-    pub required: bool,
+    pub no_default: bool,
+    #[allow(dead_code)]
+    pub optional: bool,
 }
 
 impl Parse for EncodingFieldAttribute {
@@ -24,8 +26,11 @@ impl Parse for EncodingFieldAttribute {
                 "ignore" => {
                     slf.ignore = true;
                 }
-                "required" => {
-                    slf.required = true;
+                "no_default" => {
+                    slf.no_default = true;
+                }
+                "optional" => {
+                    slf.optional = true;
                 }
                 _ => return Err(syn::Error::new_spanned(ident, "Unknown attribute value")),
             }
@@ -42,6 +47,46 @@ impl ItemAttr for EncodingFieldAttribute {
     fn combine(&mut self, other: Self) {
         self.rename = other.rename;
         self.ignore |= other.ignore;
-        self.required |= other.required;
+        self.no_default |= other.no_default;
+        self.optional |= other.optional;
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct EncodingVariantAttribute {
+    pub rename: Option<String>,
+    pub default: bool,
+}
+
+impl ItemAttr for EncodingVariantAttribute {
+    fn combine(&mut self, other: Self) {
+        self.rename = other.rename;
+        self.default |= other.default;
+    }
+}
+
+impl Parse for EncodingVariantAttribute {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut slf = Self::default();
+
+        loop {
+            let ident: Ident = input.parse()?;
+            match ident.to_string().as_str() {
+                "rename" => {
+                    input.parse::<Token![=]>()?;
+                    let val: LitStr = input.parse()?;
+                    slf.rename = Some(val.value());
+                }
+                "default" => {
+                    slf.default = true;
+                }
+                _ => return Err(syn::Error::new_spanned(ident, "Unknown attribute value")),
+            }
+            if !input.peek(Token![,]) {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+        Ok(slf)
     }
 }

--- a/opcua-macros/src/encoding/enums.rs
+++ b/opcua-macros/src/encoding/enums.rs
@@ -1,0 +1,207 @@
+use proc_macro2::TokenStream;
+use syn::{Attribute, DataEnum, Expr, Ident, Type, Variant};
+
+use crate::utils::ItemAttr;
+use quote::quote;
+
+use super::attribute::EncodingVariantAttribute;
+
+pub struct SimpleEnumVariant {
+    pub value: Expr,
+    pub name: Ident,
+    pub attr: EncodingVariantAttribute,
+}
+
+pub struct SimpleEnum {
+    pub repr: Type,
+    pub variants: Vec<SimpleEnumVariant>,
+    pub ident: Ident,
+}
+
+impl SimpleEnumVariant {
+    pub fn from_variant(variant: Variant) -> syn::Result<Self> {
+        let Some((_, value)) = variant.discriminant else {
+            return Err(syn::Error::new_spanned(
+                variant,
+                "Enum variant must have explicit discriminant",
+            ));
+        };
+        if !variant.fields.is_empty() {
+            return Err(syn::Error::new_spanned(
+                variant.fields,
+                "Macro not applicable to enums with content",
+            ));
+        }
+        let mut final_attr = EncodingVariantAttribute::default();
+        for attr in variant.attrs {
+            if attr.path().segments.len() == 1
+                && attr
+                    .path()
+                    .segments
+                    .first()
+                    .is_some_and(|s| s.ident == "opcua")
+            {
+                let data: EncodingVariantAttribute = attr.parse_args()?;
+                final_attr.combine(data);
+            }
+        }
+        Ok(Self {
+            value,
+            name: variant.ident,
+            attr: final_attr,
+        })
+    }
+}
+
+impl SimpleEnum {
+    pub fn from_input(
+        input: DataEnum,
+        attributes: Vec<Attribute>,
+        ident: Ident,
+    ) -> syn::Result<Self> {
+        let variants = input
+            .variants
+            .into_iter()
+            .map(SimpleEnumVariant::from_variant)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut repr: Option<Type> = None;
+        for attr in attributes {
+            if attr.path().segments.len() == 1
+                && attr
+                    .path()
+                    .segments
+                    .first()
+                    .is_some_and(|s| s.ident == "repr")
+            {
+                repr = Some(attr.parse_args()?);
+            }
+        }
+
+        let Some(repr) = repr else {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "Enum must be annotated with an explicit #[repr(...)] attribute",
+            ));
+        };
+
+        Ok(Self {
+            repr,
+            variants,
+            ident,
+        })
+    }
+}
+
+pub fn derive_ua_enum_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+    let ident = en.ident;
+    let repr = en.repr;
+
+    let mut try_from_arms = quote! {};
+    let mut as_str_arms = quote! {};
+    let mut from_str_arms = quote! {};
+    let mut default_ident: Option<Ident> = None;
+
+    for variant in en.variants {
+        if variant.attr.default {
+            if default_ident.is_some() {
+                return Err(syn::Error::new_spanned(
+                    variant.name,
+                    "Enum may only have one default variant",
+                ));
+            }
+
+            default_ident = Some(variant.name.clone());
+        }
+
+        let val = variant.value;
+        let name = variant.name;
+        let name_str = if let Some(rename) = variant.attr.rename {
+            rename
+        } else {
+            name.to_string()
+        };
+        try_from_arms.extend(quote! {
+            #val => Self::#name,
+        });
+        as_str_arms.extend(quote! {
+            Self::#name => #name_str,
+        });
+        from_str_arms.extend(quote! {
+            #name_str => Self::#name,
+        });
+    }
+
+    let error_msg = format!("Got unexpected value for enum {}: {{}}", ident);
+
+    let default_impl = if let Some(default_ident) = default_ident {
+        quote! {
+            impl Default for #ident {
+                fn default() -> Self {
+                    Self::#default_ident
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    Ok(quote! {
+        impl From<#ident> for #repr {
+            fn from(value: #ident) -> #repr {
+                value as #repr
+            }
+        }
+
+        #default_impl
+
+        impl opcua::types::IntoVariant for #ident {
+            fn into_variant(self) -> opcua::types::Variant {
+                (self as #repr).into_variant()
+            }
+        }
+
+        impl TryFrom<#repr> for #ident {
+            type Error = opcua::types::Error;
+            fn try_from(value: #repr) -> Result<Self, opcua::types::Error> {
+                Ok(match value {
+                    #try_from_arms
+                    r => {
+                        return Err(opcua::types::Error::decoding(format!(
+                            #error_msg, r
+                        )))
+                    }
+                })
+            }
+        }
+
+        impl opcua::types::UaEnum for #ident {
+            type Repr = #repr;
+
+            fn from_repr(repr: Self::Repr) -> Result<Self, opcua::types::Error> {
+                Self::try_from(repr)
+            }
+
+            fn into_repr(self) -> Self::Repr {
+                self.into()
+            }
+
+            fn as_str(&self) -> &'static str {
+                match self {
+                    #as_str_arms
+                }
+            }
+
+            fn from_str(val: &str) -> Result<Self, opcua::types::Error> {
+                Ok(match val {
+                    #from_str_arms
+                    r => {
+                        return Err(opcua::types::Error::decoding(format!(
+                            #error_msg, r
+                        )))
+                    }
+                })
+            }
+        }
+    })
+}

--- a/opcua-macros/src/encoding/mod.rs
+++ b/opcua-macros/src/encoding/mod.rs
@@ -1,14 +1,24 @@
 use attribute::EncodingFieldAttribute;
-use binary::{generate_binary_decode_impl, generate_binary_encode_impl};
-use json::{generate_json_decode_impl, generate_json_encode_impl};
-use proc_macro2::TokenStream;
+use binary::{
+    generate_binary_decode_impl, generate_binary_encode_impl,
+    generate_simple_enum_binary_decode_impl, generate_simple_enum_binary_encode_impl,
+};
+use enums::{derive_ua_enum_impl, SimpleEnum};
+#[cfg(feature = "json")]
+use json::{
+    generate_json_decode_impl, generate_json_encode_impl, generate_simple_enum_json_decode_impl,
+    generate_simple_enum_json_encode_impl,
+};
+use proc_macro2::{Span, TokenStream};
 use syn::DeriveInput;
-use xml::generate_xml_impl;
+#[cfg(feature = "xml")]
+use xml::{generate_simple_enum_xml_impl, generate_xml_impl};
 
 use crate::utils::{EmptyAttribute, StructItem};
 
 mod attribute;
 mod binary;
+mod enums;
 #[cfg(feature = "json")]
 mod json;
 #[cfg(feature = "xml")]
@@ -16,13 +26,48 @@ mod xml;
 
 pub(crate) type EncodingStruct = StructItem<EncodingFieldAttribute, EmptyAttribute>;
 
-pub(crate) fn parse_encoding_input(input: DeriveInput) -> syn::Result<EncodingStruct> {
-    EncodingStruct::from_input(input)
+pub(crate) enum EncodingInput {
+    Struct(EncodingStruct),
+    SimpleEnum(SimpleEnum),
+}
+
+impl EncodingInput {
+    pub fn from_derive_input(input: DeriveInput) -> syn::Result<Self> {
+        match input.data {
+            syn::Data::Struct(data_struct) => Ok(Self::Struct(EncodingStruct::from_input(
+                data_struct,
+                input.attrs,
+                input.ident,
+            )?)),
+            syn::Data::Enum(data_enum) => {
+                let is_union = data_enum
+                    .variants
+                    .first()
+                    .is_some_and(|v| !v.fields.is_empty());
+                if is_union {
+                    return Err(syn::Error::new_spanned(
+                        input.ident,
+                        "Only simple unions without variant contents is currently supported",
+                    ));
+                }
+                Ok(Self::SimpleEnum(SimpleEnum::from_input(
+                    data_enum,
+                    input.attrs,
+                    input.ident,
+                )?))
+            }
+            syn::Data::Union(_) => Err(syn::Error::new_spanned(
+                input.ident,
+                "Unions are not supported",
+            )),
+        }
+    }
 }
 
 pub enum EncodingToImpl {
     BinaryEncode,
     BinaryDecode,
+    UaEnum,
     #[cfg(feature = "json")]
     JsonEncode,
     #[cfg(feature = "json")]
@@ -35,16 +80,39 @@ pub fn generate_encoding_impl(
     input: DeriveInput,
     target: EncodingToImpl,
 ) -> syn::Result<TokenStream> {
-    let input = parse_encoding_input(input)?;
+    let input = EncodingInput::from_derive_input(input)?;
 
-    match target {
-        EncodingToImpl::BinaryEncode => generate_binary_encode_impl(input),
-        EncodingToImpl::BinaryDecode => generate_binary_decode_impl(input),
+    match (target, input) {
+        (EncodingToImpl::BinaryEncode, EncodingInput::Struct(s)) => generate_binary_encode_impl(s),
+        (EncodingToImpl::BinaryEncode, EncodingInput::SimpleEnum(s)) => {
+            generate_simple_enum_binary_encode_impl(s)
+        }
+        (EncodingToImpl::BinaryDecode, EncodingInput::Struct(s)) => generate_binary_decode_impl(s),
+        (EncodingToImpl::BinaryDecode, EncodingInput::SimpleEnum(s)) => {
+            generate_simple_enum_binary_decode_impl(s)
+        }
+
         #[cfg(feature = "json")]
-        EncodingToImpl::JsonEncode => generate_json_encode_impl(input),
+        (EncodingToImpl::JsonEncode, EncodingInput::Struct(s)) => generate_json_encode_impl(s),
         #[cfg(feature = "json")]
-        EncodingToImpl::JsonDecode => generate_json_decode_impl(input),
+        (EncodingToImpl::JsonEncode, EncodingInput::SimpleEnum(s)) => {
+            generate_simple_enum_json_encode_impl(s)
+        }
+        #[cfg(feature = "json")]
+        (EncodingToImpl::JsonDecode, EncodingInput::Struct(s)) => generate_json_decode_impl(s),
+        #[cfg(feature = "json")]
+        (EncodingToImpl::JsonDecode, EncodingInput::SimpleEnum(s)) => {
+            generate_simple_enum_json_decode_impl(s)
+        }
         #[cfg(feature = "xml")]
-        EncodingToImpl::FromXml => generate_xml_impl(input),
+        (EncodingToImpl::FromXml, EncodingInput::Struct(s)) => generate_xml_impl(s),
+        #[cfg(feature = "xml")]
+        (EncodingToImpl::FromXml, EncodingInput::SimpleEnum(s)) => generate_simple_enum_xml_impl(s),
+
+        (EncodingToImpl::UaEnum, EncodingInput::SimpleEnum(s)) => derive_ua_enum_impl(s),
+        (EncodingToImpl::UaEnum, _) => Err(syn::Error::new(
+            Span::call_site(),
+            "UaEnum derive macro is only supported on simple enums",
+        )),
     }
 }

--- a/opcua-macros/src/encoding/xml.rs
+++ b/opcua-macros/src/encoding/xml.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 
 use quote::quote;
 
-use super::EncodingStruct;
+use super::{enums::SimpleEnum, EncodingStruct};
 
 pub fn generate_xml_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
     let ident = strct.ident;
@@ -32,6 +32,23 @@ pub fn generate_xml_impl(strct: EncodingStruct) -> syn::Result<TokenStream> {
                 Ok(Self {
                     #build
                 })
+            }
+        }
+    })
+}
+
+pub fn generate_simple_enum_xml_impl(en: SimpleEnum) -> syn::Result<TokenStream> {
+    let ident = en.ident;
+    let repr = en.repr;
+
+    Ok(quote! {
+        impl opcua::types::xml::FromXml for #ident {
+            fn from_xml<'a>(
+                element: &opcua::types::xml::XmlElement,
+                ctx: &opcua::types::xml::XmlContext<'a>
+            ) -> Result<Self, opcua::types::xml::FromXmlError> {
+                let val = #repr::from_xml(element, ctx)?;
+                Ok(Self::try_from(val).map_err(|e| e.to_string())?)
             }
         }
     })

--- a/opcua-macros/src/events/field.rs
+++ b/opcua-macros/src/events/field.rs
@@ -2,7 +2,7 @@ use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use syn::DeriveInput;
 
-use crate::utils::{EmptyAttribute, StructItem};
+use crate::utils::{expect_struct, EmptyAttribute, StructItem};
 
 use super::parse::EventFieldAttribute;
 
@@ -11,7 +11,7 @@ use quote::quote;
 pub type EventFieldStruct = StructItem<EventFieldAttribute, EmptyAttribute>;
 
 pub fn parse_event_field_struct(input: DeriveInput) -> syn::Result<EventFieldStruct> {
-    EventFieldStruct::from_input(input)
+    EventFieldStruct::from_input(expect_struct(input.data)?, input.attrs, input.ident)
 }
 
 pub fn generate_event_field_impls(event: EventFieldStruct) -> syn::Result<TokenStream> {

--- a/opcua-macros/src/events/parse.rs
+++ b/opcua-macros/src/events/parse.rs
@@ -4,7 +4,7 @@ use base64::Engine;
 use syn::{parse::Parse, DeriveInput, Ident, LitStr, Token, Type};
 use uuid::Uuid;
 
-use crate::utils::{ItemAttr, StructItem};
+use crate::utils::{expect_struct, ItemAttr, StructItem};
 
 #[derive(Default, Debug)]
 pub(super) struct EventFieldAttribute {
@@ -137,7 +137,7 @@ impl ItemAttr for EventAttribute {
 pub type EventStruct = StructItem<EventFieldAttribute, EventAttribute>;
 
 pub fn parse_event_struct(input: DeriveInput) -> syn::Result<EventStruct> {
-    let mut parsed = EventStruct::from_input(input)?;
+    let mut parsed = EventStruct::from_input(expect_struct(input.data)?, input.attrs, input.ident)?;
 
     let mut filtered_fields = Vec::with_capacity(parsed.fields.len());
 

--- a/opcua-macros/src/lib.rs
+++ b/opcua-macros/src/lib.rs
@@ -74,7 +74,7 @@ pub fn derive_event_field(item: TokenStream) -> TokenStream {
 
 #[cfg(feature = "xml")]
 #[proc_macro_derive(FromXml, attributes(opcua))]
-/// Derive the `FromXml` trait on this struct, creating a conversion from
+/// Derive the `FromXml` trait on this struct or enum, creating a conversion from
 /// NodeSet2 XML files.
 ///
 /// All fields must be marked with `opcua(ignore)` or implement `FromXml`.
@@ -87,7 +87,7 @@ pub fn derive_from_xml(item: TokenStream) -> TokenStream {
 
 #[cfg(feature = "json")]
 #[proc_macro_derive(JsonEncodable, attributes(opcua))]
-/// Derive the `JsonEncodable` trait on this struct, creating code
+/// Derive the `JsonEncodable` trait on this struct or enum, creating code
 /// to write the struct to a JSON stream on OPC-UA reversible encoding.
 ///
 /// All fields must be marked with `opcua(ignore)` or implement `JsonEncodable`.
@@ -100,7 +100,7 @@ pub fn derive_json_encodable(item: TokenStream) -> TokenStream {
 
 #[cfg(feature = "json")]
 #[proc_macro_derive(JsonDecodable, attributes(opcua))]
-/// Derive the `JsonDecodable` trait on this struct, creating code
+/// Derive the `JsonDecodable` trait on this struct or enum, creating code
 /// to read the struct from an OPC-UA stream with reversible encoding.
 ///
 /// All fields must be marked with `opcua(ignore)` or implement `JsonDecodable`.
@@ -112,7 +112,7 @@ pub fn derive_json_decodable(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(BinaryEncodable, attributes(opcua))]
-/// Derive the `BinaryEncodable` trait on this struct, creating code
+/// Derive the `BinaryEncodable` trait on this struct or enum, creating code
 /// to write the struct to an OPC-UA binary stream.
 ///
 /// All fields must be marked with `opcua(ignore)` or implement `BinaryEncodable`.
@@ -124,12 +124,26 @@ pub fn derive_binary_encodable(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(BinaryDecodable, attributes(opcua))]
-/// Derive the `BinaryDecodable` trait on this struct, creating code
+/// Derive the `BinaryDecodable` trait on this struct or enum, creating code
 /// to read the struct from an OPC-UA binary stream.
 ///
 /// All fields must be marked with `opcua(ignore)` or implement `BinaryDecodable`.
 pub fn derive_binary_decodable(item: TokenStream) -> TokenStream {
     match generate_encoding_impl(parse_macro_input!(item), EncodingToImpl::BinaryDecode) {
+        Ok(r) => r.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_derive(UaEnum, attributes(opcua))]
+/// Derive the `UaEnum` trait on this simple enum, creating code to convert it
+/// to and from OPC-UA string representation and its numeric representation.
+/// The enum must have a `repr([int])` attribute.
+///
+/// This also implements `TryFrom<[int]>` for the given `repr`, `Into<[int]>`, `IntoVariant`, and `Default`
+/// if a variant is labeled with `#[opcua(default)]`
+pub fn derive_ua_enum(item: TokenStream) -> TokenStream {
+    match generate_encoding_impl(parse_macro_input!(item), EncodingToImpl::UaEnum) {
         Ok(r) => r.into(),
         Err(e) => e.to_compile_error().into(),
     }

--- a/opcua-types/src/generated/types/enums.rs
+++ b/opcua-types/src/generated/types/enums.rs
@@ -280,102 +280,28 @@ impl opcua::types::json::JsonEncodable for AlarmMask {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum ApplicationType {
+    #[opcua(default)]
     Server = 0i32,
     Client = 1i32,
     ClientAndServer = 2i32,
     DiscoveryServer = 3i32,
-}
-impl Default for ApplicationType {
-    fn default() -> Self {
-        Self::Server
-    }
-}
-impl TryFrom<i32> for ApplicationType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Server,
-            1i32 => Self::Client,
-            2i32 => Self::ClientAndServer,
-            3i32 => Self::DiscoveryServer,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum ApplicationType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for ApplicationType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum ApplicationType: {}", e))?)
-    }
-}
-impl From<ApplicationType> for i32 {
-    fn from(value: ApplicationType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for ApplicationType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for ApplicationType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for ApplicationType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for ApplicationType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for ApplicationType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct AttributeWriteMask : i32 { const
@@ -452,305 +378,93 @@ impl opcua::types::json::JsonEncodable for AttributeWriteMask {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum AxisScaleEnumeration {
+    #[opcua(default)]
     Linear = 0i32,
     Log = 1i32,
     Ln = 2i32,
 }
-impl Default for AxisScaleEnumeration {
-    fn default() -> Self {
-        Self::Linear
-    }
-}
-impl TryFrom<i32> for AxisScaleEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Linear,
-            1i32 => Self::Log,
-            2i32 => Self::Ln,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum AxisScaleEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for AxisScaleEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum AxisScaleEnumeration: {}", e))?)
-    }
-}
-impl From<AxisScaleEnumeration> for i32 {
-    fn from(value: AxisScaleEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for AxisScaleEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for AxisScaleEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for AxisScaleEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for AxisScaleEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for AxisScaleEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum BrokerTransportQualityOfService {
+    #[opcua(default)]
     NotSpecified = 0i32,
     BestEffort = 1i32,
     AtLeastOnce = 2i32,
     AtMostOnce = 3i32,
     ExactlyOnce = 4i32,
 }
-impl Default for BrokerTransportQualityOfService {
-    fn default() -> Self {
-        Self::NotSpecified
-    }
-}
-impl TryFrom<i32> for BrokerTransportQualityOfService {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::NotSpecified,
-            1i32 => Self::BestEffort,
-            2i32 => Self::AtLeastOnce,
-            3i32 => Self::AtMostOnce,
-            4i32 => Self::ExactlyOnce,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum BrokerTransportQualityOfService: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for BrokerTransportQualityOfService {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum BrokerTransportQualityOfService: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<BrokerTransportQualityOfService> for i32 {
-    fn from(value: BrokerTransportQualityOfService) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for BrokerTransportQualityOfService {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for BrokerTransportQualityOfService {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for BrokerTransportQualityOfService {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for BrokerTransportQualityOfService {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for BrokerTransportQualityOfService {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum BrowseDirection {
+    #[opcua(default)]
     Forward = 0i32,
     Inverse = 1i32,
     Both = 2i32,
     Invalid = 3i32,
 }
-impl Default for BrowseDirection {
-    fn default() -> Self {
-        Self::Forward
-    }
-}
-impl TryFrom<i32> for BrowseDirection {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Forward,
-            1i32 => Self::Inverse,
-            2i32 => Self::Both,
-            3i32 => Self::Invalid,
-            r => {
-                log::warn!(
-                    "Got unexpected value for enum BrowseDirection: {}. Falling back on Invalid",
-                    r
-                );
-                Self::Invalid
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for BrowseDirection {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum BrowseDirection: {}", e))?)
-    }
-}
-impl From<BrowseDirection> for i32 {
-    fn from(value: BrowseDirection) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for BrowseDirection {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for BrowseDirection {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for BrowseDirection {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for BrowseDirection {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for BrowseDirection {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum BrowseResultMask {
+    #[opcua(default)]
     None = 0i32,
     ReferenceTypeId = 1i32,
     IsForward = 2i32,
@@ -762,290 +476,49 @@ pub enum BrowseResultMask {
     ReferenceTypeInfo = 3i32,
     TargetInfo = 60i32,
 }
-impl Default for BrowseResultMask {
-    fn default() -> Self {
-        Self::None
-    }
-}
-impl TryFrom<i32> for BrowseResultMask {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::None,
-            1i32 => Self::ReferenceTypeId,
-            2i32 => Self::IsForward,
-            4i32 => Self::NodeClass,
-            8i32 => Self::BrowseName,
-            16i32 => Self::DisplayName,
-            32i32 => Self::TypeDefinition,
-            63i32 => Self::All,
-            3i32 => Self::ReferenceTypeInfo,
-            60i32 => Self::TargetInfo,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum BrowseResultMask: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for BrowseResultMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum BrowseResultMask: {}", e))?)
-    }
-}
-impl From<BrowseResultMask> for i32 {
-    fn from(value: BrowseResultMask) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for BrowseResultMask {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for BrowseResultMask {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for BrowseResultMask {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for BrowseResultMask {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for BrowseResultMask {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum ConversionLimitEnum {
+    #[opcua(default)]
     NoConversion = 0i32,
     Limited = 1i32,
     Unlimited = 2i32,
 }
-impl Default for ConversionLimitEnum {
-    fn default() -> Self {
-        Self::NoConversion
-    }
-}
-impl TryFrom<i32> for ConversionLimitEnum {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::NoConversion,
-            1i32 => Self::Limited,
-            2i32 => Self::Unlimited,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum ConversionLimitEnum: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for ConversionLimitEnum {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum ConversionLimitEnum: {}", e))?)
-    }
-}
-impl From<ConversionLimitEnum> for i32 {
-    fn from(value: ConversionLimitEnum) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for ConversionLimitEnum {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for ConversionLimitEnum {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for ConversionLimitEnum {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for ConversionLimitEnum {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for ConversionLimitEnum {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum DataChangeTrigger {
+    #[opcua(default)]
     Status = 0i32,
     StatusValue = 1i32,
     StatusValueTimestamp = 2i32,
-}
-impl Default for DataChangeTrigger {
-    fn default() -> Self {
-        Self::Status
-    }
-}
-impl TryFrom<i32> for DataChangeTrigger {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Status,
-            1i32 => Self::StatusValue,
-            2i32 => Self::StatusValueTimestamp,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum DataChangeTrigger: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for DataChangeTrigger {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum DataChangeTrigger: {}", e))?)
-    }
-}
-impl From<DataChangeTrigger> for i32 {
-    fn from(value: DataChangeTrigger) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for DataChangeTrigger {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for DataChangeTrigger {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for DataChangeTrigger {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for DataChangeTrigger {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for DataChangeTrigger {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct DataSetFieldContentMask : i32 {
@@ -1181,389 +654,95 @@ impl opcua::types::json::JsonEncodable for DataSetFieldFlags {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum DataSetOrderingType {
+    #[opcua(default)]
     Undefined = 0i32,
     AscendingWriterId = 1i32,
     AscendingWriterIdSingle = 2i32,
 }
-impl Default for DataSetOrderingType {
-    fn default() -> Self {
-        Self::Undefined
-    }
-}
-impl TryFrom<i32> for DataSetOrderingType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Undefined,
-            1i32 => Self::AscendingWriterId,
-            2i32 => Self::AscendingWriterIdSingle,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum DataSetOrderingType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for DataSetOrderingType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum DataSetOrderingType: {}", e))?)
-    }
-}
-impl From<DataSetOrderingType> for i32 {
-    fn from(value: DataSetOrderingType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for DataSetOrderingType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for DataSetOrderingType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for DataSetOrderingType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for DataSetOrderingType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for DataSetOrderingType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum DeadbandType {
+    #[opcua(default)]
     None = 0i32,
     Absolute = 1i32,
     Percent = 2i32,
 }
-impl Default for DeadbandType {
-    fn default() -> Self {
-        Self::None
-    }
-}
-impl TryFrom<i32> for DeadbandType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::None,
-            1i32 => Self::Absolute,
-            2i32 => Self::Percent,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum DeadbandType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for DeadbandType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum DeadbandType: {}", e))?)
-    }
-}
-impl From<DeadbandType> for i32 {
-    fn from(value: DeadbandType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for DeadbandType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for DeadbandType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for DeadbandType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for DeadbandType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for DeadbandType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum DiagnosticsLevel {
+    #[opcua(default)]
     Basic = 0i32,
     Advanced = 1i32,
     Info = 2i32,
     Log = 3i32,
     Debug = 4i32,
 }
-impl Default for DiagnosticsLevel {
-    fn default() -> Self {
-        Self::Basic
-    }
-}
-impl TryFrom<i32> for DiagnosticsLevel {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Basic,
-            1i32 => Self::Advanced,
-            2i32 => Self::Info,
-            3i32 => Self::Log,
-            4i32 => Self::Debug,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum DiagnosticsLevel: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for DiagnosticsLevel {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum DiagnosticsLevel: {}", e))?)
-    }
-}
-impl From<DiagnosticsLevel> for i32 {
-    fn from(value: DiagnosticsLevel) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for DiagnosticsLevel {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for DiagnosticsLevel {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for DiagnosticsLevel {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for DiagnosticsLevel {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for DiagnosticsLevel {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum Duplex {
+    #[opcua(default)]
     Full = 0i32,
     Half = 1i32,
     Unknown = 2i32,
-}
-impl Default for Duplex {
-    fn default() -> Self {
-        Self::Full
-    }
-}
-impl TryFrom<i32> for Duplex {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Full,
-            1i32 => Self::Half,
-            2i32 => Self::Unknown,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum Duplex: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for Duplex {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum Duplex: {}", e))?)
-    }
-}
-impl From<Duplex> for i32 {
-    fn from(value: Duplex) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for Duplex {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for Duplex {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for Duplex {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for Duplex {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for Duplex {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct EventNotifierType : u8 { const
@@ -1632,112 +811,48 @@ impl opcua::types::json::JsonEncodable for EventNotifierType {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum ExceptionDeviationFormat {
+    #[opcua(default)]
     AbsoluteValue = 0i32,
     PercentOfValue = 1i32,
     PercentOfRange = 2i32,
     PercentOfEURange = 3i32,
     Unknown = 4i32,
 }
-impl Default for ExceptionDeviationFormat {
-    fn default() -> Self {
-        Self::AbsoluteValue
-    }
-}
-impl TryFrom<i32> for ExceptionDeviationFormat {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::AbsoluteValue,
-            1i32 => Self::PercentOfValue,
-            2i32 => Self::PercentOfRange,
-            3i32 => Self::PercentOfEURange,
-            4i32 => Self::Unknown,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum ExceptionDeviationFormat: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for ExceptionDeviationFormat {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum ExceptionDeviationFormat: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<ExceptionDeviationFormat> for i32 {
-    fn from(value: ExceptionDeviationFormat) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for ExceptionDeviationFormat {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for ExceptionDeviationFormat {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for ExceptionDeviationFormat {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for ExceptionDeviationFormat {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for ExceptionDeviationFormat {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum FilterOperator {
+    #[opcua(default)]
     Equals = 0i32,
     IsNull = 1i32,
     GreaterThan = 2i32,
@@ -1757,110 +872,21 @@ pub enum FilterOperator {
     BitwiseAnd = 16i32,
     BitwiseOr = 17i32,
 }
-impl Default for FilterOperator {
-    fn default() -> Self {
-        Self::Equals
-    }
-}
-impl TryFrom<i32> for FilterOperator {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Equals,
-            1i32 => Self::IsNull,
-            2i32 => Self::GreaterThan,
-            3i32 => Self::LessThan,
-            4i32 => Self::GreaterThanOrEqual,
-            5i32 => Self::LessThanOrEqual,
-            6i32 => Self::Like,
-            7i32 => Self::Not,
-            8i32 => Self::Between,
-            9i32 => Self::InList,
-            10i32 => Self::And,
-            11i32 => Self::Or,
-            12i32 => Self::Cast,
-            13i32 => Self::InView,
-            14i32 => Self::OfType,
-            15i32 => Self::RelatedTo,
-            16i32 => Self::BitwiseAnd,
-            17i32 => Self::BitwiseOr,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum FilterOperator: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for FilterOperator {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum FilterOperator: {}", e))?)
-    }
-}
-impl From<FilterOperator> for i32 {
-    fn from(value: FilterOperator) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for FilterOperator {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for FilterOperator {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for FilterOperator {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for FilterOperator {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for FilterOperator {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum HistoryUpdateType {
     Insert = 1i32,
@@ -1868,91 +894,21 @@ pub enum HistoryUpdateType {
     Update = 3i32,
     Delete = 4i32,
 }
-impl TryFrom<i32> for HistoryUpdateType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            1i32 => Self::Insert,
-            2i32 => Self::Replace,
-            3i32 => Self::Update,
-            4i32 => Self::Delete,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum HistoryUpdateType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for HistoryUpdateType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum HistoryUpdateType: {}", e))?)
-    }
-}
-impl From<HistoryUpdateType> for i32 {
-    fn from(value: HistoryUpdateType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for HistoryUpdateType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for HistoryUpdateType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for HistoryUpdateType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for HistoryUpdateType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for HistoryUpdateType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum IdentityCriteriaType {
     UserName = 1i32,
@@ -1964,289 +920,69 @@ pub enum IdentityCriteriaType {
     Application = 7i32,
     X509Subject = 8i32,
 }
-impl TryFrom<i32> for IdentityCriteriaType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            1i32 => Self::UserName,
-            2i32 => Self::Thumbprint,
-            3i32 => Self::Role,
-            4i32 => Self::GroupId,
-            5i32 => Self::Anonymous,
-            6i32 => Self::AuthenticatedUser,
-            7i32 => Self::Application,
-            8i32 => Self::X509Subject,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum IdentityCriteriaType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for IdentityCriteriaType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum IdentityCriteriaType: {}", e))?)
-    }
-}
-impl From<IdentityCriteriaType> for i32 {
-    fn from(value: IdentityCriteriaType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for IdentityCriteriaType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for IdentityCriteriaType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for IdentityCriteriaType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for IdentityCriteriaType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for IdentityCriteriaType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum IdType {
+    #[opcua(default)]
     Numeric = 0i32,
     String = 1i32,
     Guid = 2i32,
     Opaque = 3i32,
 }
-impl Default for IdType {
-    fn default() -> Self {
-        Self::Numeric
-    }
-}
-impl TryFrom<i32> for IdType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Numeric,
-            1i32 => Self::String,
-            2i32 => Self::Guid,
-            3i32 => Self::Opaque,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum IdType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for IdType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum IdType: {}", e))?)
-    }
-}
-impl From<IdType> for i32 {
-    fn from(value: IdType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for IdType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for IdType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for IdType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for IdType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for IdType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum InterfaceAdminStatus {
+    #[opcua(default)]
     Up = 0i32,
     Down = 1i32,
     Testing = 2i32,
 }
-impl Default for InterfaceAdminStatus {
-    fn default() -> Self {
-        Self::Up
-    }
-}
-impl TryFrom<i32> for InterfaceAdminStatus {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Up,
-            1i32 => Self::Down,
-            2i32 => Self::Testing,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum InterfaceAdminStatus: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for InterfaceAdminStatus {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum InterfaceAdminStatus: {}", e))?)
-    }
-}
-impl From<InterfaceAdminStatus> for i32 {
-    fn from(value: InterfaceAdminStatus) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for InterfaceAdminStatus {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for InterfaceAdminStatus {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for InterfaceAdminStatus {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for InterfaceAdminStatus {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for InterfaceAdminStatus {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum InterfaceOperStatus {
+    #[opcua(default)]
     Up = 0i32,
     Down = 1i32,
     Testing = 2i32,
@@ -2254,98 +990,6 @@ pub enum InterfaceOperStatus {
     Dormant = 4i32,
     NotPresent = 5i32,
     LowerLayerDown = 6i32,
-}
-impl Default for InterfaceOperStatus {
-    fn default() -> Self {
-        Self::Up
-    }
-}
-impl TryFrom<i32> for InterfaceOperStatus {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Up,
-            1i32 => Self::Down,
-            2i32 => Self::Testing,
-            3i32 => Self::Unknown,
-            4i32 => Self::Dormant,
-            5i32 => Self::NotPresent,
-            6i32 => Self::LowerLayerDown,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum InterfaceOperStatus: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for InterfaceOperStatus {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum InterfaceOperStatus: {}", e))?)
-    }
-}
-impl From<InterfaceOperStatus> for i32 {
-    fn from(value: InterfaceOperStatus) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for InterfaceOperStatus {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for InterfaceOperStatus {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for InterfaceOperStatus {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for InterfaceOperStatus {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for InterfaceOperStatus {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct JsonDataSetMessageContentMask :
@@ -2486,105 +1130,44 @@ impl opcua::types::json::JsonEncodable for JsonNetworkMessageContentMask {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum MessageSecurityMode {
+    #[opcua(default)]
     Invalid = 0i32,
     None = 1i32,
     Sign = 2i32,
     SignAndEncrypt = 3i32,
 }
-impl Default for MessageSecurityMode {
-    fn default() -> Self {
-        Self::Invalid
-    }
-}
-impl TryFrom<i32> for MessageSecurityMode {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Invalid,
-            1i32 => Self::None,
-            2i32 => Self::Sign,
-            3i32 => Self::SignAndEncrypt,
-            r => {
-                log::warn!(
-                        "Got unexpected value for enum MessageSecurityMode: {}. Falling back on Invalid",
-                        r
-                    );
-                Self::Invalid
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for MessageSecurityMode {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum MessageSecurityMode: {}", e))?)
-    }
-}
-impl From<MessageSecurityMode> for i32 {
-    fn from(value: MessageSecurityMode) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for MessageSecurityMode {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for MessageSecurityMode {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for MessageSecurityMode {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for MessageSecurityMode {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for MessageSecurityMode {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum ModelChangeStructureVerbMask {
     NodeAdded = 1i32,
@@ -2593,382 +1176,91 @@ pub enum ModelChangeStructureVerbMask {
     ReferenceDeleted = 8i32,
     DataTypeChanged = 16i32,
 }
-impl TryFrom<i32> for ModelChangeStructureVerbMask {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            1i32 => Self::NodeAdded,
-            2i32 => Self::NodeDeleted,
-            4i32 => Self::ReferenceAdded,
-            8i32 => Self::ReferenceDeleted,
-            16i32 => Self::DataTypeChanged,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum ModelChangeStructureVerbMask: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for ModelChangeStructureVerbMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum ModelChangeStructureVerbMask: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<ModelChangeStructureVerbMask> for i32 {
-    fn from(value: ModelChangeStructureVerbMask) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for ModelChangeStructureVerbMask {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for ModelChangeStructureVerbMask {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for ModelChangeStructureVerbMask {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for ModelChangeStructureVerbMask {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for ModelChangeStructureVerbMask {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum MonitoringMode {
+    #[opcua(default)]
     Disabled = 0i32,
     Sampling = 1i32,
     Reporting = 2i32,
 }
-impl Default for MonitoringMode {
-    fn default() -> Self {
-        Self::Disabled
-    }
-}
-impl TryFrom<i32> for MonitoringMode {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Disabled,
-            1i32 => Self::Sampling,
-            2i32 => Self::Reporting,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum MonitoringMode: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for MonitoringMode {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum MonitoringMode: {}", e))?)
-    }
-}
-impl From<MonitoringMode> for i32 {
-    fn from(value: MonitoringMode) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for MonitoringMode {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for MonitoringMode {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for MonitoringMode {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for MonitoringMode {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for MonitoringMode {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum NamingRuleType {
     Mandatory = 1i32,
     Optional = 2i32,
     Constraint = 3i32,
 }
-impl TryFrom<i32> for NamingRuleType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            1i32 => Self::Mandatory,
-            2i32 => Self::Optional,
-            3i32 => Self::Constraint,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum NamingRuleType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for NamingRuleType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum NamingRuleType: {}", e))?)
-    }
-}
-impl From<NamingRuleType> for i32 {
-    fn from(value: NamingRuleType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for NamingRuleType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for NamingRuleType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for NamingRuleType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for NamingRuleType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for NamingRuleType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum NegotiationStatus {
+    #[opcua(default)]
     InProgress = 0i32,
     Complete = 1i32,
     Failed = 2i32,
     Unknown = 3i32,
     NoNegotiation = 4i32,
 }
-impl Default for NegotiationStatus {
-    fn default() -> Self {
-        Self::InProgress
-    }
-}
-impl TryFrom<i32> for NegotiationStatus {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::InProgress,
-            1i32 => Self::Complete,
-            2i32 => Self::Failed,
-            3i32 => Self::Unknown,
-            4i32 => Self::NoNegotiation,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum NegotiationStatus: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for NegotiationStatus {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum NegotiationStatus: {}", e))?)
-    }
-}
-impl From<NegotiationStatus> for i32 {
-    fn from(value: NegotiationStatus) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for NegotiationStatus {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for NegotiationStatus {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for NegotiationStatus {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for NegotiationStatus {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for NegotiationStatus {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum NodeAttributesMask {
+    #[opcua(default)]
     None = 0i32,
     AccessLevel = 1i32,
     ArrayDimensions = 2i32,
@@ -3005,129 +1297,24 @@ pub enum NodeAttributesMask {
     ReferenceType = 26537060i32,
     View = 26501356i32,
 }
-impl Default for NodeAttributesMask {
-    fn default() -> Self {
-        Self::None
-    }
-}
-impl TryFrom<i32> for NodeAttributesMask {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::None,
-            1i32 => Self::AccessLevel,
-            2i32 => Self::ArrayDimensions,
-            4i32 => Self::BrowseName,
-            8i32 => Self::ContainsNoLoops,
-            16i32 => Self::DataType,
-            32i32 => Self::Description,
-            64i32 => Self::DisplayName,
-            128i32 => Self::EventNotifier,
-            256i32 => Self::Executable,
-            512i32 => Self::Historizing,
-            1024i32 => Self::InverseName,
-            2048i32 => Self::IsAbstract,
-            4096i32 => Self::MinimumSamplingInterval,
-            8192i32 => Self::NodeClass,
-            16384i32 => Self::NodeId,
-            32768i32 => Self::Symmetric,
-            65536i32 => Self::UserAccessLevel,
-            131072i32 => Self::UserExecutable,
-            262144i32 => Self::UserWriteMask,
-            524288i32 => Self::ValueRank,
-            1048576i32 => Self::WriteMask,
-            2097152i32 => Self::Value,
-            4194304i32 => Self::DataTypeDefinition,
-            8388608i32 => Self::RolePermissions,
-            16777216i32 => Self::AccessRestrictions,
-            33554431i32 => Self::All,
-            26501220i32 => Self::BaseNode,
-            26501348i32 => Self::Object,
-            26503268i32 => Self::ObjectType,
-            26571383i32 => Self::Variable,
-            28600438i32 => Self::VariableType,
-            26632548i32 => Self::Method,
-            26537060i32 => Self::ReferenceType,
-            26501356i32 => Self::View,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum NodeAttributesMask: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for NodeAttributesMask {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum NodeAttributesMask: {}", e))?)
-    }
-}
-impl From<NodeAttributesMask> for i32 {
-    fn from(value: NodeAttributesMask) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for NodeAttributesMask {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for NodeAttributesMask {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for NodeAttributesMask {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for NodeAttributesMask {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for NodeAttributesMask {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum NodeClass {
+    #[opcua(default)]
     Unspecified = 0i32,
     Object = 1i32,
     Variable = 2i32,
@@ -3138,104 +1325,25 @@ pub enum NodeClass {
     DataType = 64i32,
     View = 128i32,
 }
-impl Default for NodeClass {
-    fn default() -> Self {
-        Self::Unspecified
-    }
-}
-impl TryFrom<i32> for NodeClass {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Unspecified,
-            1i32 => Self::Object,
-            2i32 => Self::Variable,
-            4i32 => Self::Method,
-            8i32 => Self::ObjectType,
-            16i32 => Self::VariableType,
-            32i32 => Self::ReferenceType,
-            64i32 => Self::DataType,
-            128i32 => Self::View,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum NodeClass: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for NodeClass {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum NodeClass: {}", e))?)
-    }
-}
-impl From<NodeClass> for i32 {
-    fn from(value: NodeClass) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for NodeClass {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for NodeClass {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for NodeClass {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for NodeClass {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for NodeClass {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
 ///The possible encodings for a NodeId value.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(u8)]
 pub enum NodeIdType {
+    #[opcua(default)]
     TwoByte = 0u8,
     FourByte = 1u8,
     Numeric = 2u8,
@@ -3243,98 +1351,21 @@ pub enum NodeIdType {
     Guid = 4u8,
     ByteString = 5u8,
 }
-impl Default for NodeIdType {
-    fn default() -> Self {
-        Self::TwoByte
-    }
-}
-impl TryFrom<u8> for NodeIdType {
-    type Error = opcua::types::Error;
-    fn try_from(value: u8) -> Result<Self, <Self as TryFrom<u8>>::Error> {
-        Ok(match value {
-            0u8 => Self::TwoByte,
-            1u8 => Self::FourByte,
-            2u8 => Self::Numeric,
-            3u8 => Self::String,
-            4u8 => Self::Guid,
-            5u8 => Self::ByteString,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum NodeIdType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for NodeIdType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = u8::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum NodeIdType: {}", e))?)
-    }
-}
-impl From<NodeIdType> for u8 {
-    fn from(value: NodeIdType) -> Self {
-        value as u8
-    }
-}
-impl opcua::types::IntoVariant for NodeIdType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as u8).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for NodeIdType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: u8 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize u8: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for NodeIdType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as u8)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for NodeIdType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        1usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_u8(stream, *self as u8)
-    }
-}
-impl opcua::types::BinaryDecodable for NodeIdType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_u8(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum OpenFileMode {
     Read = 1i32,
@@ -3342,184 +1373,27 @@ pub enum OpenFileMode {
     EraseExisting = 4i32,
     Append = 8i32,
 }
-impl TryFrom<i32> for OpenFileMode {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            1i32 => Self::Read,
-            2i32 => Self::Write,
-            4i32 => Self::EraseExisting,
-            8i32 => Self::Append,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum OpenFileMode: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for OpenFileMode {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum OpenFileMode: {}", e))?)
-    }
-}
-impl From<OpenFileMode> for i32 {
-    fn from(value: OpenFileMode) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for OpenFileMode {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for OpenFileMode {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for OpenFileMode {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for OpenFileMode {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for OpenFileMode {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum OverrideValueHandling {
+    #[opcua(default)]
     Disabled = 0i32,
     LastUsableValue = 1i32,
     OverrideValue = 2i32,
-}
-impl Default for OverrideValueHandling {
-    fn default() -> Self {
-        Self::Disabled
-    }
-}
-impl TryFrom<i32> for OverrideValueHandling {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Disabled,
-            1i32 => Self::LastUsableValue,
-            2i32 => Self::OverrideValue,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum OverrideValueHandling: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for OverrideValueHandling {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum OverrideValueHandling: {}", e))?)
-    }
-}
-impl From<OverrideValueHandling> for i32 {
-    fn from(value: OverrideValueHandling) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for OverrideValueHandling {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for OverrideValueHandling {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for OverrideValueHandling {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for OverrideValueHandling {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for OverrideValueHandling {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct PasswordOptionsMask : i32 { const
@@ -3591,97 +1465,27 @@ impl opcua::types::json::JsonEncodable for PasswordOptionsMask {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PerformUpdateType {
     Insert = 1i32,
     Replace = 2i32,
     Update = 3i32,
     Remove = 4i32,
-}
-impl TryFrom<i32> for PerformUpdateType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            1i32 => Self::Insert,
-            2i32 => Self::Replace,
-            3i32 => Self::Update,
-            4i32 => Self::Remove,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PerformUpdateType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PerformUpdateType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum PerformUpdateType: {}", e))?)
-    }
-}
-impl From<PerformUpdateType> for i32 {
-    fn from(value: PerformUpdateType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PerformUpdateType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PerformUpdateType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PerformUpdateType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PerformUpdateType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PerformUpdateType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct PermissionType : i32 { const None
@@ -3825,205 +1629,69 @@ impl opcua::types::json::JsonEncodable for PubSubConfigurationRefMask {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PubSubDiagnosticsCounterClassification {
+    #[opcua(default)]
     Information = 0i32,
     Error = 1i32,
 }
-impl Default for PubSubDiagnosticsCounterClassification {
-    fn default() -> Self {
-        Self::Information
-    }
-}
-impl TryFrom<i32> for PubSubDiagnosticsCounterClassification {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Information,
-            1i32 => Self::Error,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PubSubDiagnosticsCounterClassification: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PubSubDiagnosticsCounterClassification {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PubSubDiagnosticsCounterClassification: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PubSubDiagnosticsCounterClassification> for i32 {
-    fn from(value: PubSubDiagnosticsCounterClassification) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PubSubDiagnosticsCounterClassification {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PubSubDiagnosticsCounterClassification {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PubSubDiagnosticsCounterClassification {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PubSubDiagnosticsCounterClassification {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PubSubDiagnosticsCounterClassification {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PubSubState {
+    #[opcua(default)]
     Disabled = 0i32,
     Paused = 1i32,
     Operational = 2i32,
     Error = 3i32,
     PreOperational = 4i32,
 }
-impl Default for PubSubState {
-    fn default() -> Self {
-        Self::Disabled
-    }
-}
-impl TryFrom<i32> for PubSubState {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Disabled,
-            1i32 => Self::Paused,
-            2i32 => Self::Operational,
-            3i32 => Self::Error,
-            4i32 => Self::PreOperational,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PubSubState: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PubSubState {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum PubSubState: {}", e))?)
-    }
-}
-impl From<PubSubState> for i32 {
-    fn from(value: PubSubState) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PubSubState {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PubSubState {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PubSubState {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PubSubState {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PubSubState {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum RedundancySupport {
+    #[opcua(default)]
     None = 0i32,
     Cold = 1i32,
     Warm = 2i32,
@@ -4031,294 +1699,68 @@ pub enum RedundancySupport {
     Transparent = 4i32,
     HotAndMirrored = 5i32,
 }
-impl Default for RedundancySupport {
-    fn default() -> Self {
-        Self::None
-    }
-}
-impl TryFrom<i32> for RedundancySupport {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::None,
-            1i32 => Self::Cold,
-            2i32 => Self::Warm,
-            3i32 => Self::Hot,
-            4i32 => Self::Transparent,
-            5i32 => Self::HotAndMirrored,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum RedundancySupport: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for RedundancySupport {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum RedundancySupport: {}", e))?)
-    }
-}
-impl From<RedundancySupport> for i32 {
-    fn from(value: RedundancySupport) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for RedundancySupport {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for RedundancySupport {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for RedundancySupport {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for RedundancySupport {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for RedundancySupport {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum RedundantServerMode {
+    #[opcua(default)]
     PrimaryWithBackup = 0i32,
     PrimaryOnly = 1i32,
     BackupReady = 2i32,
     BackupNotReady = 3i32,
 }
-impl Default for RedundantServerMode {
-    fn default() -> Self {
-        Self::PrimaryWithBackup
-    }
-}
-impl TryFrom<i32> for RedundantServerMode {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::PrimaryWithBackup,
-            1i32 => Self::PrimaryOnly,
-            2i32 => Self::BackupReady,
-            3i32 => Self::BackupNotReady,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum RedundantServerMode: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for RedundantServerMode {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum RedundantServerMode: {}", e))?)
-    }
-}
-impl From<RedundantServerMode> for i32 {
-    fn from(value: RedundantServerMode) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for RedundantServerMode {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for RedundantServerMode {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for RedundantServerMode {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for RedundantServerMode {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for RedundantServerMode {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum SecurityTokenRequestType {
+    #[opcua(default)]
     Issue = 0i32,
     Renew = 1i32,
 }
-impl Default for SecurityTokenRequestType {
-    fn default() -> Self {
-        Self::Issue
-    }
-}
-impl TryFrom<i32> for SecurityTokenRequestType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Issue,
-            1i32 => Self::Renew,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum SecurityTokenRequestType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for SecurityTokenRequestType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum SecurityTokenRequestType: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<SecurityTokenRequestType> for i32 {
-    fn from(value: SecurityTokenRequestType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for SecurityTokenRequestType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for SecurityTokenRequestType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for SecurityTokenRequestType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for SecurityTokenRequestType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for SecurityTokenRequestType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum ServerState {
+    #[opcua(default)]
     Running = 0i32,
     Failed = 1i32,
     NoConfiguration = 2i32,
@@ -4328,398 +1770,78 @@ pub enum ServerState {
     CommunicationFault = 6i32,
     Unknown = 7i32,
 }
-impl Default for ServerState {
-    fn default() -> Self {
-        Self::Running
-    }
-}
-impl TryFrom<i32> for ServerState {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Running,
-            1i32 => Self::Failed,
-            2i32 => Self::NoConfiguration,
-            3i32 => Self::Suspended,
-            4i32 => Self::Shutdown,
-            5i32 => Self::Test,
-            6i32 => Self::CommunicationFault,
-            7i32 => Self::Unknown,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum ServerState: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for ServerState {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum ServerState: {}", e))?)
-    }
-}
-impl From<ServerState> for i32 {
-    fn from(value: ServerState) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for ServerState {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for ServerState {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for ServerState {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for ServerState {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for ServerState {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum StructureType {
+    #[opcua(default)]
     Structure = 0i32,
     StructureWithOptionalFields = 1i32,
     Union = 2i32,
     StructureWithSubtypedValues = 3i32,
     UnionWithSubtypedValues = 4i32,
 }
-impl Default for StructureType {
-    fn default() -> Self {
-        Self::Structure
-    }
-}
-impl TryFrom<i32> for StructureType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Structure,
-            1i32 => Self::StructureWithOptionalFields,
-            2i32 => Self::Union,
-            3i32 => Self::StructureWithSubtypedValues,
-            4i32 => Self::UnionWithSubtypedValues,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum StructureType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for StructureType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum StructureType: {}", e))?)
-    }
-}
-impl From<StructureType> for i32 {
-    fn from(value: StructureType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for StructureType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for StructureType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for StructureType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for StructureType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for StructureType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum TimestampsToReturn {
+    #[opcua(default)]
     Source = 0i32,
     Server = 1i32,
     Both = 2i32,
     Neither = 3i32,
     Invalid = 4i32,
 }
-impl Default for TimestampsToReturn {
-    fn default() -> Self {
-        Self::Source
-    }
-}
-impl TryFrom<i32> for TimestampsToReturn {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Source,
-            1i32 => Self::Server,
-            2i32 => Self::Both,
-            3i32 => Self::Neither,
-            4i32 => Self::Invalid,
-            r => {
-                log::warn!(
-                    "Got unexpected value for enum TimestampsToReturn: {}. Falling back on Invalid",
-                    r
-                );
-                Self::Invalid
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for TimestampsToReturn {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum TimestampsToReturn: {}", e))?)
-    }
-}
-impl From<TimestampsToReturn> for i32 {
-    fn from(value: TimestampsToReturn) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for TimestampsToReturn {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for TimestampsToReturn {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for TimestampsToReturn {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for TimestampsToReturn {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for TimestampsToReturn {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum TrustListMasks {
+    #[opcua(default)]
     None = 0i32,
     TrustedCertificates = 1i32,
     TrustedCrls = 2i32,
     IssuerCertificates = 4i32,
     IssuerCrls = 8i32,
     All = 15i32,
-}
-impl Default for TrustListMasks {
-    fn default() -> Self {
-        Self::None
-    }
-}
-impl TryFrom<i32> for TrustListMasks {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::None,
-            1i32 => Self::TrustedCertificates,
-            2i32 => Self::TrustedCrls,
-            4i32 => Self::IssuerCertificates,
-            8i32 => Self::IssuerCrls,
-            15i32 => Self::All,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum TrustListMasks: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for TrustListMasks {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum TrustListMasks: {}", e))?)
-    }
-}
-impl From<TrustListMasks> for i32 {
-    fn from(value: TrustListMasks) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for TrustListMasks {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for TrustListMasks {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for TrustListMasks {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for TrustListMasks {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for TrustListMasks {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct TrustListValidationOptions : i32
@@ -4791,9 +1913,24 @@ impl opcua::types::json::JsonEncodable for TrustListValidationOptions {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum TsnFailureCode {
+    #[opcua(default)]
     NoFailure = 0i32,
     InsufficientBandwidth = 1i32,
     InsufficientResources = 2i32,
@@ -4821,407 +1958,74 @@ pub enum TsnFailureCode {
     StreamIdTypeNotSupported = 24i32,
     FeatureNotSupported = 25i32,
 }
-impl Default for TsnFailureCode {
-    fn default() -> Self {
-        Self::NoFailure
-    }
-}
-impl TryFrom<i32> for TsnFailureCode {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::NoFailure,
-            1i32 => Self::InsufficientBandwidth,
-            2i32 => Self::InsufficientResources,
-            3i32 => Self::InsufficientTrafficClassBandwidth,
-            4i32 => Self::StreamIdInUse,
-            5i32 => Self::StreamDestinationAddressInUse,
-            6i32 => Self::StreamPreemptedByHigherRank,
-            7i32 => Self::LatencyHasChanged,
-            8i32 => Self::EgressPortNotAvbCapable,
-            9i32 => Self::UseDifferentDestinationAddress,
-            10i32 => Self::OutOfMsrpResources,
-            11i32 => Self::OutOfMmrpResources,
-            12i32 => Self::CannotStoreDestinationAddress,
-            13i32 => Self::PriorityIsNotAnSrcClass,
-            14i32 => Self::MaxFrameSizeTooLarge,
-            15i32 => Self::MaxFanInPortsLimitReached,
-            16i32 => Self::FirstValueChangedForStreamId,
-            17i32 => Self::VlanBlockedOnEgress,
-            18i32 => Self::VlanTaggingDisabledOnEgress,
-            19i32 => Self::SrClassPriorityMismatch,
-            20i32 => Self::FeatureNotPropagated,
-            21i32 => Self::MaxLatencyExceeded,
-            22i32 => Self::BridgeDoesNotProvideNetworkId,
-            23i32 => Self::StreamTransformNotSupported,
-            24i32 => Self::StreamIdTypeNotSupported,
-            25i32 => Self::FeatureNotSupported,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum TsnFailureCode: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for TsnFailureCode {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum TsnFailureCode: {}", e))?)
-    }
-}
-impl From<TsnFailureCode> for i32 {
-    fn from(value: TsnFailureCode) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for TsnFailureCode {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for TsnFailureCode {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for TsnFailureCode {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for TsnFailureCode {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for TsnFailureCode {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum TsnListenerStatus {
+    #[opcua(default)]
     None = 0i32,
     Ready = 1i32,
     PartialFailed = 2i32,
     Failed = 3i32,
 }
-impl Default for TsnListenerStatus {
-    fn default() -> Self {
-        Self::None
-    }
-}
-impl TryFrom<i32> for TsnListenerStatus {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::None,
-            1i32 => Self::Ready,
-            2i32 => Self::PartialFailed,
-            3i32 => Self::Failed,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum TsnListenerStatus: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for TsnListenerStatus {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum TsnListenerStatus: {}", e))?)
-    }
-}
-impl From<TsnListenerStatus> for i32 {
-    fn from(value: TsnListenerStatus) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for TsnListenerStatus {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for TsnListenerStatus {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for TsnListenerStatus {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for TsnListenerStatus {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for TsnListenerStatus {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum TsnStreamState {
+    #[opcua(default)]
     Disabled = 0i32,
     Configuring = 1i32,
     Ready = 2i32,
     Operational = 3i32,
     Error = 4i32,
 }
-impl Default for TsnStreamState {
-    fn default() -> Self {
-        Self::Disabled
-    }
-}
-impl TryFrom<i32> for TsnStreamState {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Disabled,
-            1i32 => Self::Configuring,
-            2i32 => Self::Ready,
-            3i32 => Self::Operational,
-            4i32 => Self::Error,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum TsnStreamState: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for TsnStreamState {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum TsnStreamState: {}", e))?)
-    }
-}
-impl From<TsnStreamState> for i32 {
-    fn from(value: TsnStreamState) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for TsnStreamState {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for TsnStreamState {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for TsnStreamState {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for TsnStreamState {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for TsnStreamState {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum TsnTalkerStatus {
+    #[opcua(default)]
     None = 0i32,
     Ready = 1i32,
     Failed = 2i32,
-}
-impl Default for TsnTalkerStatus {
-    fn default() -> Self {
-        Self::None
-    }
-}
-impl TryFrom<i32> for TsnTalkerStatus {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::None,
-            1i32 => Self::Ready,
-            2i32 => Self::Failed,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum TsnTalkerStatus: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for TsnTalkerStatus {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum TsnTalkerStatus: {}", e))?)
-    }
-}
-impl From<TsnTalkerStatus> for i32 {
-    fn from(value: TsnTalkerStatus) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for TsnTalkerStatus {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for TsnTalkerStatus {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for TsnTalkerStatus {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for TsnTalkerStatus {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for TsnTalkerStatus {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct UadpDataSetMessageContentMask :
@@ -5428,100 +2232,26 @@ impl opcua::types::json::JsonEncodable for UserConfigurationMask {
         Ok(())
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum UserTokenType {
+    #[opcua(default)]
     Anonymous = 0i32,
     UserName = 1i32,
     Certificate = 2i32,
     IssuedToken = 3i32,
-}
-impl Default for UserTokenType {
-    fn default() -> Self {
-        Self::Anonymous
-    }
-}
-impl TryFrom<i32> for UserTokenType {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::Anonymous,
-            1i32 => Self::UserName,
-            2i32 => Self::Certificate,
-            3i32 => Self::IssuedToken,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum UserTokenType: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for UserTokenType {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum UserTokenType: {}", e))?)
-    }
-}
-impl From<UserTokenType> for i32 {
-    fn from(value: UserTokenType) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for UserTokenType {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for UserTokenType {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for UserTokenType {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for UserTokenType {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for UserTokenType {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }

--- a/opcua-types/src/lib.rs
+++ b/opcua-types/src/lib.rs
@@ -284,6 +284,8 @@ pub use opcua_macros::JsonEncodable;
 
 pub use opcua_macros::BinaryDecodable;
 pub use opcua_macros::BinaryEncodable;
+pub use opcua_macros::UaEnum;
+mod ua_enum;
 
 pub use self::{
     add_node_attributes::AddNodeAttributes,
@@ -315,6 +317,7 @@ pub use self::{
     status_code::*,
     string::*,
     type_loader::*,
+    ua_enum::*,
     variant::*,
 };
 

--- a/opcua-types/src/ua_enum.rs
+++ b/opcua-types/src/ua_enum.rs
@@ -1,0 +1,21 @@
+use crate::Error;
+
+/// Trait implemented by simple OPC-UA enums and bitfields.
+pub trait UaEnum: Sized {
+    /// The numeric type used to represent this enum when encoded.
+    type Repr: Copy;
+
+    /// Convert from a numeric value to an instance of this enum.
+    fn from_repr(repr: Self::Repr) -> Result<Self, Error>;
+
+    /// Convert this enum into its numeric representation.
+    fn into_repr(self) -> Self::Repr;
+
+    /// Get the string representation of this enum,
+    /// on the form `[NAME]_[REPRESENTATION]`, i.e. `KEY_1`.
+    fn as_str(&self) -> &'static str;
+
+    /// Convert from the string representation of this enum to its value,
+    /// on the form `[NAME]_[REPRESENTATION]`, i.e. `KEY_1`.
+    fn from_str(val: &str) -> Result<Self, Error>;
+}

--- a/samples/custom-codegen/src/generated/types/enums.rs
+++ b/samples/custom-codegen/src/generated/types/enums.rs
@@ -7,904 +7,228 @@
 // Copyright (C) 2017-2024 Einar Omang
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum IMTagSelectorEnumeration {
+    #[opcua(default)]
     FUNCTION = 0i32,
     LOCATION = 1i32,
     BOTH = 2i32,
 }
-impl Default for IMTagSelectorEnumeration {
-    fn default() -> Self {
-        Self::FUNCTION
-    }
-}
-impl TryFrom<i32> for IMTagSelectorEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::FUNCTION,
-            1i32 => Self::LOCATION,
-            2i32 => Self::BOTH,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum IMTagSelectorEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for IMTagSelectorEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum IMTagSelectorEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<IMTagSelectorEnumeration> for i32 {
-    fn from(value: IMTagSelectorEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for IMTagSelectorEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for IMTagSelectorEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for IMTagSelectorEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for IMTagSelectorEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for IMTagSelectorEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnARStateEnumeration {
+    #[opcua(default)]
     CONNECTED = 0i32,
     UNCONNECTED = 1i32,
     UNCONNECTED_ERR_DEVICE_NOT_FOUND = 2i32,
     UNCONNECTED_ERR_DUPLICATE_IP = 3i32,
     UNCONNECTED_ERR_DUPLICATE_NOS = 4i32,
 }
-impl Default for PnARStateEnumeration {
-    fn default() -> Self {
-        Self::CONNECTED
-    }
-}
-impl TryFrom<i32> for PnARStateEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::CONNECTED,
-            1i32 => Self::UNCONNECTED,
-            2i32 => Self::UNCONNECTED_ERR_DEVICE_NOT_FOUND,
-            3i32 => Self::UNCONNECTED_ERR_DUPLICATE_IP,
-            4i32 => Self::UNCONNECTED_ERR_DUPLICATE_NOS,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnARStateEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnARStateEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum PnARStateEnumeration: {}", e))?)
-    }
-}
-impl From<PnARStateEnumeration> for i32 {
-    fn from(value: PnARStateEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnARStateEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnARStateEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnARStateEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnARStateEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnARStateEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnARTypeEnumeration {
+    #[opcua(default)]
     IOCARSingle = 0i32,
     IOSAR = 6i32,
     IOCARSingleUsingRT_CLASS_3 = 16i32,
     IOCARSR = 32i32,
 }
-impl Default for PnARTypeEnumeration {
-    fn default() -> Self {
-        Self::IOCARSingle
-    }
-}
-impl TryFrom<i32> for PnARTypeEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::IOCARSingle,
-            6i32 => Self::IOSAR,
-            16i32 => Self::IOCARSingleUsingRT_CLASS_3,
-            32i32 => Self::IOCARSR,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnARTypeEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnARTypeEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val)
-            .map_err(|e| format!("Got unexpected value for enum PnARTypeEnumeration: {}", e))?)
-    }
-}
-impl From<PnARTypeEnumeration> for i32 {
-    fn from(value: PnARTypeEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnARTypeEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnARTypeEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnARTypeEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnARTypeEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnARTypeEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnAssetChangeEnumeration {
+    #[opcua(default)]
     INSERTED = 0i32,
     REMOVED = 1i32,
     CHANGED = 2i32,
 }
-impl Default for PnAssetChangeEnumeration {
-    fn default() -> Self {
-        Self::INSERTED
-    }
-}
-impl TryFrom<i32> for PnAssetChangeEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::INSERTED,
-            1i32 => Self::REMOVED,
-            2i32 => Self::CHANGED,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnAssetChangeEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnAssetChangeEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnAssetChangeEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnAssetChangeEnumeration> for i32 {
-    fn from(value: PnAssetChangeEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnAssetChangeEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnAssetChangeEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnAssetChangeEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnAssetChangeEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnAssetChangeEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnAssetTypeEnumeration {
+    #[opcua(default)]
     DEVICE = 0i32,
     MODULE = 1i32,
     SUBMODULE = 2i32,
     ASSET = 3i32,
 }
-impl Default for PnAssetTypeEnumeration {
-    fn default() -> Self {
-        Self::DEVICE
-    }
-}
-impl TryFrom<i32> for PnAssetTypeEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::DEVICE,
-            1i32 => Self::MODULE,
-            2i32 => Self::SUBMODULE,
-            3i32 => Self::ASSET,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnAssetTypeEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnAssetTypeEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnAssetTypeEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnAssetTypeEnumeration> for i32 {
-    fn from(value: PnAssetTypeEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnAssetTypeEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnAssetTypeEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnAssetTypeEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnAssetTypeEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnAssetTypeEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnChannelAccumulativeEnumeration {
+    #[opcua(default)]
     SINGLE = 0i32,
     ACCUMULATIVE = 256i32,
 }
-impl Default for PnChannelAccumulativeEnumeration {
-    fn default() -> Self {
-        Self::SINGLE
-    }
-}
-impl TryFrom<i32> for PnChannelAccumulativeEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::SINGLE,
-            256i32 => Self::ACCUMULATIVE,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnChannelAccumulativeEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnChannelAccumulativeEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnChannelAccumulativeEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnChannelAccumulativeEnumeration> for i32 {
-    fn from(value: PnChannelAccumulativeEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnChannelAccumulativeEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnChannelAccumulativeEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnChannelAccumulativeEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnChannelAccumulativeEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnChannelAccumulativeEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnChannelDirectionEnumeration {
+    #[opcua(default)]
     MANUFACTURER_SPECIFIC = 0i32,
     INPUT_CHANNEL = 8192i32,
     OUTPUT_CHANNEL = 16384i32,
     BIDIRECTIONAL_CHANNEL = 24576i32,
 }
-impl Default for PnChannelDirectionEnumeration {
-    fn default() -> Self {
-        Self::MANUFACTURER_SPECIFIC
-    }
-}
-impl TryFrom<i32> for PnChannelDirectionEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::MANUFACTURER_SPECIFIC,
-            8192i32 => Self::INPUT_CHANNEL,
-            16384i32 => Self::OUTPUT_CHANNEL,
-            24576i32 => Self::BIDIRECTIONAL_CHANNEL,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnChannelDirectionEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnChannelDirectionEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnChannelDirectionEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnChannelDirectionEnumeration> for i32 {
-    fn from(value: PnChannelDirectionEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnChannelDirectionEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnChannelDirectionEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnChannelDirectionEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnChannelDirectionEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnChannelDirectionEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnChannelMaintenanceEnumeration {
+    #[opcua(default)]
     FAULT = 0i32,
     MAINTENANCE_REQUIRED = 512i32,
     MAINTENANCE_DEMANDED = 1024i32,
     USE_QUALIFIED_CHANNEL_QUALIFIER = 1536i32,
 }
-impl Default for PnChannelMaintenanceEnumeration {
-    fn default() -> Self {
-        Self::FAULT
-    }
-}
-impl TryFrom<i32> for PnChannelMaintenanceEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::FAULT,
-            512i32 => Self::MAINTENANCE_REQUIRED,
-            1024i32 => Self::MAINTENANCE_DEMANDED,
-            1536i32 => Self::USE_QUALIFIED_CHANNEL_QUALIFIER,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnChannelMaintenanceEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnChannelMaintenanceEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnChannelMaintenanceEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnChannelMaintenanceEnumeration> for i32 {
-    fn from(value: PnChannelMaintenanceEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnChannelMaintenanceEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnChannelMaintenanceEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnChannelMaintenanceEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnChannelMaintenanceEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnChannelMaintenanceEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnChannelSpecifierEnumeration {
+    #[opcua(default)]
     ALL_DISAPPEARS = 0i32,
     APPEARS = 2048i32,
     DISAPPEARS = 4096i32,
     DISAPPEARS_OTHER_REMAIN = 6144i32,
 }
-impl Default for PnChannelSpecifierEnumeration {
-    fn default() -> Self {
-        Self::ALL_DISAPPEARS
-    }
-}
-impl TryFrom<i32> for PnChannelSpecifierEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::ALL_DISAPPEARS,
-            2048i32 => Self::APPEARS,
-            4096i32 => Self::DISAPPEARS,
-            6144i32 => Self::DISAPPEARS_OTHER_REMAIN,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnChannelSpecifierEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnChannelSpecifierEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnChannelSpecifierEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnChannelSpecifierEnumeration> for i32 {
-    fn from(value: PnChannelSpecifierEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnChannelSpecifierEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnChannelSpecifierEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnChannelSpecifierEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnChannelSpecifierEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnChannelSpecifierEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnChannelTypeEnumeration {
+    #[opcua(default)]
     UNSPECIFIC = 0i32,
     __1BIT = 1i32,
     __2BIT = 2i32,
@@ -914,205 +238,44 @@ pub enum PnChannelTypeEnumeration {
     __32BIT = 6i32,
     __64BIT = 7i32,
 }
-impl Default for PnChannelTypeEnumeration {
-    fn default() -> Self {
-        Self::UNSPECIFIC
-    }
-}
-impl TryFrom<i32> for PnChannelTypeEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::UNSPECIFIC,
-            1i32 => Self::__1BIT,
-            2i32 => Self::__2BIT,
-            3i32 => Self::__4BIT,
-            4i32 => Self::__8BIT,
-            5i32 => Self::__16BIT,
-            6i32 => Self::__32BIT,
-            7i32 => Self::__64BIT,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnChannelTypeEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnChannelTypeEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnChannelTypeEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnChannelTypeEnumeration> for i32 {
-    fn from(value: PnChannelTypeEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnChannelTypeEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnChannelTypeEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnChannelTypeEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnChannelTypeEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnChannelTypeEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnDeviceStateEnumeration {
+    #[opcua(default)]
     OFFLINE = 0i32,
     OFFLINE_DOCKING = 1i32,
     ONLINE = 2i32,
     ONLINE_DOCKING = 3i32,
 }
-impl Default for PnDeviceStateEnumeration {
-    fn default() -> Self {
-        Self::OFFLINE
-    }
-}
-impl TryFrom<i32> for PnDeviceStateEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::OFFLINE,
-            1i32 => Self::OFFLINE_DOCKING,
-            2i32 => Self::ONLINE,
-            3i32 => Self::ONLINE_DOCKING,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnDeviceStateEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnDeviceStateEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnDeviceStateEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnDeviceStateEnumeration> for i32 {
-    fn from(value: PnDeviceStateEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnDeviceStateEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnDeviceStateEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnDeviceStateEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnDeviceStateEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnDeviceStateEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnLinkStateEnumeration {
     UP = 1i32,
@@ -1123,203 +286,48 @@ pub enum PnLinkStateEnumeration {
     NOT_PRESENT = 6i32,
     LOWER_LAYER_DOWN = 7i32,
 }
-impl TryFrom<i32> for PnLinkStateEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            1i32 => Self::UP,
-            2i32 => Self::DOWN,
-            3i32 => Self::TESTING,
-            4i32 => Self::UNKNOWN,
-            5i32 => Self::DORMANT,
-            6i32 => Self::NOT_PRESENT,
-            7i32 => Self::LOWER_LAYER_DOWN,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnLinkStateEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnLinkStateEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnLinkStateEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnLinkStateEnumeration> for i32 {
-    fn from(value: PnLinkStateEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnLinkStateEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnLinkStateEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnLinkStateEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnLinkStateEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnLinkStateEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnModuleStateEnumeration {
+    #[opcua(default)]
     NO_MODULE = 0i32,
     WRONG_MODULE = 1i32,
     PROPER_MODULE = 2i32,
     SUBSTITUTE = 3i32,
     OK = 4i32,
 }
-impl Default for PnModuleStateEnumeration {
-    fn default() -> Self {
-        Self::NO_MODULE
-    }
-}
-impl TryFrom<i32> for PnModuleStateEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::NO_MODULE,
-            1i32 => Self::WRONG_MODULE,
-            2i32 => Self::PROPER_MODULE,
-            3i32 => Self::SUBSTITUTE,
-            4i32 => Self::OK,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnModuleStateEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnModuleStateEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnModuleStateEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnModuleStateEnumeration> for i32 {
-    fn from(value: PnModuleStateEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnModuleStateEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnModuleStateEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnModuleStateEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnModuleStateEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnModuleStateEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnPortStateEnumeration {
+    #[opcua(default)]
     UNKNOWN = 0i32,
     DISABLED_DISCARDING = 1i32,
     BLOCKING = 2i32,
@@ -1328,400 +336,71 @@ pub enum PnPortStateEnumeration {
     FORWARDING = 5i32,
     BROKEN = 6i32,
 }
-impl Default for PnPortStateEnumeration {
-    fn default() -> Self {
-        Self::UNKNOWN
-    }
-}
-impl TryFrom<i32> for PnPortStateEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::UNKNOWN,
-            1i32 => Self::DISABLED_DISCARDING,
-            2i32 => Self::BLOCKING,
-            3i32 => Self::LISTENING,
-            4i32 => Self::LEARNING,
-            5i32 => Self::FORWARDING,
-            6i32 => Self::BROKEN,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnPortStateEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnPortStateEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnPortStateEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnPortStateEnumeration> for i32 {
-    fn from(value: PnPortStateEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnPortStateEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnPortStateEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnPortStateEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnPortStateEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnPortStateEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnSubmoduleAddInfoEnumeration {
+    #[opcua(default)]
     NO_ADD_INFO = 0i32,
     TAKEOVER_NOT_ALLOWED = 1i32,
 }
-impl Default for PnSubmoduleAddInfoEnumeration {
-    fn default() -> Self {
-        Self::NO_ADD_INFO
-    }
-}
-impl TryFrom<i32> for PnSubmoduleAddInfoEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::NO_ADD_INFO,
-            1i32 => Self::TAKEOVER_NOT_ALLOWED,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnSubmoduleAddInfoEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnSubmoduleAddInfoEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnSubmoduleAddInfoEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnSubmoduleAddInfoEnumeration> for i32 {
-    fn from(value: PnSubmoduleAddInfoEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnSubmoduleAddInfoEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnSubmoduleAddInfoEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnSubmoduleAddInfoEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnSubmoduleAddInfoEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnSubmoduleAddInfoEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnSubmoduleARInfoEnumeration {
+    #[opcua(default)]
     OWN = 0i32,
     APPLICATION_READY_PENDING = 128i32,
     SUPERORDINATED_LOCKED = 256i32,
     LOCKED_BY_IO_CONTROLLER = 384i32,
     LOCKED_BY_IO_SUPERVISOR = 512i32,
 }
-impl Default for PnSubmoduleARInfoEnumeration {
-    fn default() -> Self {
-        Self::OWN
-    }
-}
-impl TryFrom<i32> for PnSubmoduleARInfoEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::OWN,
-            128i32 => Self::APPLICATION_READY_PENDING,
-            256i32 => Self::SUPERORDINATED_LOCKED,
-            384i32 => Self::LOCKED_BY_IO_CONTROLLER,
-            512i32 => Self::LOCKED_BY_IO_SUPERVISOR,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnSubmoduleARInfoEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnSubmoduleARInfoEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnSubmoduleARInfoEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnSubmoduleARInfoEnumeration> for i32 {
-    fn from(value: PnSubmoduleARInfoEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnSubmoduleARInfoEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnSubmoduleARInfoEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnSubmoduleARInfoEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnSubmoduleARInfoEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnSubmoduleARInfoEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    opcua::types::UaEnum,
+    opcua::types::BinaryEncodable,
+    opcua::types::BinaryDecodable,
+)]
+#[cfg_attr(
+    feature = "json",
+    derive(opcua::types::JsonEncodable, opcua::types::JsonDecodable)
+)]
+#[cfg_attr(feature = "xml", derive(opcua::types::FromXml))]
 #[repr(i32)]
 pub enum PnSubmoduleIdentInfoEnumeration {
+    #[opcua(default)]
     OK = 0i32,
     SUBSTITUTE = 2048i32,
     WRONG = 4096i32,
     NO_SUBMODULE = 6144i32,
-}
-impl Default for PnSubmoduleIdentInfoEnumeration {
-    fn default() -> Self {
-        Self::OK
-    }
-}
-impl TryFrom<i32> for PnSubmoduleIdentInfoEnumeration {
-    type Error = opcua::types::Error;
-    fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(match value {
-            0i32 => Self::OK,
-            2048i32 => Self::SUBSTITUTE,
-            4096i32 => Self::WRONG,
-            6144i32 => Self::NO_SUBMODULE,
-            r => {
-                return Err(opcua::types::Error::decoding(format!(
-                    "Got unexpected value for enum PnSubmoduleIdentInfoEnumeration: {}",
-                    r
-                )));
-            }
-        })
-    }
-}
-#[cfg(feature = "xml")]
-impl opcua::types::xml::FromXml for PnSubmoduleIdentInfoEnumeration {
-    fn from_xml(
-        element: &opcua::types::xml::XmlElement,
-        ctx: &opcua::types::xml::XmlContext<'_>,
-    ) -> Result<Self, opcua::types::xml::FromXmlError> {
-        let val = i32::from_xml(element, ctx)?;
-        Ok(Self::try_from(val).map_err(|e| {
-            format!(
-                "Got unexpected value for enum PnSubmoduleIdentInfoEnumeration: {}",
-                e
-            )
-        })?)
-    }
-}
-impl From<PnSubmoduleIdentInfoEnumeration> for i32 {
-    fn from(value: PnSubmoduleIdentInfoEnumeration) -> Self {
-        value as i32
-    }
-}
-impl opcua::types::IntoVariant for PnSubmoduleIdentInfoEnumeration {
-    fn into_variant(self) -> opcua::types::Variant {
-        (self as i32).into_variant()
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonDecodable for PnSubmoduleIdentInfoEnumeration {
-    fn decode(
-        stream: &mut opcua::types::json::JsonStreamReader<&mut dyn std::io::Read>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        use opcua::types::json::JsonReader;
-        let value: i32 = stream.next_number()??;
-        Self::try_from(value).map_err(|e| {
-            opcua::types::Error::decoding(format!("Failed to deserialize i32: {:?}", e))
-        })
-    }
-}
-#[cfg(feature = "json")]
-impl opcua::types::json::JsonEncodable for PnSubmoduleIdentInfoEnumeration {
-    fn encode(
-        &self,
-        stream: &mut opcua::types::json::JsonStreamWriter<&mut dyn std::io::Write>,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        use opcua::types::json::JsonWriter;
-        stream.number_value(*self as i32)?;
-        Ok(())
-    }
-}
-impl opcua::types::BinaryEncodable for PnSubmoduleIdentInfoEnumeration {
-    fn byte_len(&self, _ctx: &opcua::types::Context<'_>) -> usize {
-        4usize
-    }
-    fn encode<S: std::io::Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<()> {
-        opcua::types::write_i32(stream, *self as i32)
-    }
-}
-impl opcua::types::BinaryDecodable for PnSubmoduleIdentInfoEnumeration {
-    fn decode<S: std::io::Read + ?Sized>(
-        stream: &mut S,
-        _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<Self> {
-        let value = opcua::types::read_i32(stream)?;
-        Self::try_from(value)
-    }
 }


### PR DESCRIPTION
Cleans up the generated code a bit and makes it easier to define your own macros. We still need something for option sets, probably a custom function-like macro.